### PR TITLE
Update to support both Forge 1.19 and 1.19.x

### DIFF
--- a/src/main/java/com/github/tartaricacid/bakadanmaku/event/post/SendDanmakuEvent.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/event/post/SendDanmakuEvent.java
@@ -4,7 +4,6 @@ package com.github.tartaricacid.bakadanmaku.event.post;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.network.chat.ChatSender;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Event;
@@ -22,7 +21,12 @@ public class SendDanmakuEvent extends Event {
     @SubscribeEvent
     public static void onSendDanmaku(SendDanmakuEvent event) {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.gui != null) {
+        try {
+            Object chatListener = minecraft.getClass().getMethod("m_240442_").invoke(minecraft);
+            // ChatListener chatListener = minecraft.getChatListener();
+            chatListener.getClass().getMethod("m_240494_", Component.class, boolean.class).invoke(chatListener, Component.literal(event.getMessage()), false);
+            // chatListener.handleSystemChat(Component.literal(event.getMessage()), false);
+        } catch (Exception e) {
             Registry<ChatType> chatTypes = RegistryAccess.BUILTIN.get().registryOrThrow(Registry.CHAT_TYPE_REGISTRY);
             ChatType chatType = chatTypes.get(ChatType.CHAT);
             if (chatType != null) {

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/input/KeybindingRegistry.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/input/KeybindingRegistry.java
@@ -1,15 +1,14 @@
 package com.github.tartaricacid.bakadanmaku.input;
 
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.ClientRegistry;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class KeybindingRegistry {
     @SubscribeEvent
-    public static void onClientSetup(FMLClientSetupEvent event) {
-        ClientRegistry.registerKeyBinding(ConfigKey.CONFIG_KEY);
+    public static void onClientSetup(RegisterKeyMappingsEvent event) {
+        event.register(ConfigKey.CONFIG_KEY);
     }
 }


### PR DESCRIPTION
Update to support both Forge 1.19 and 1.19.x
Also update the 1.19 Forge API to 41.1.0
Forge Version may not be lower than 41.0.64, because Forge change it key register in this version
Tested on Forge 1.19-41.1.0 and 1.19.2-43.1.1