### PR TITLE
修复获取信息流认证秘钥时没有Wbi签名的问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
@@ -18,7 +18,7 @@ import java.util.TreeMap;
 public class WbiSigner {
     private static final String NAV_URL = "https://api.bilibili.com/x/web-interface/nav";
     private static final Gson GSON = new Gson();
-    private static final PercentEscaper escaper = new PercentEscaper("", false);
+    private static final PercentEscaper escaper = new PercentEscaper("-_.~", false);
 
     private static final int[] MIXIN_KEY_ENC_TAB = new int[]{
             46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
@@ -30,13 +30,21 @@ public class WbiSigner {
     static String WbiSign(Map<String, String> params) {
         long wts = System.currentTimeMillis() / 1000L;
 
-        Map<String, String> copiedParams = new TreeMap<>(params);
-        String wRid = DigestUtils.md5Hex(encodeQuery(copiedParams) + getMixinKey());
+        String query = encodeQuery(params);
 
-        params.put("wts", String.valueOf(wts));
-        params.put("w_rid", wRid);
+        Map<String, String> forSign = new TreeMap<>();
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            String v = e.getValue() == null ? "" : e.getValue();
 
-        return encodeQuery(params);
+            v = v.replaceAll("[!'()*]", "");
+            forSign.put(e.getKey(), v);
+        }
+        forSign.put("wts", String.valueOf(wts));
+
+        String mixinKey = getMixinKey();
+        String wRid = DigestUtils.md5Hex((encodeQuery(forSign) + mixinKey).getBytes(StandardCharsets.UTF_8));
+
+        return query + "&wts=" + wts + "&w_rid=" + wRid;
     }
 
     static String encodeQuery(Map<String, String> params) {

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
@@ -1,12 +1,13 @@
 package com.github.tartaricacid.bakadanmaku.site.bilibili;
 
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.IOUtils;
-
+import com.github.tartaricacid.bakadanmaku.BakaDanmaku;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.PercentEscaper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.google.common.net.PercentEscaper;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -14,11 +15,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.TreeMap;
 
-
+/**
+ * 参考自：<a href="https://socialsisteryi.github.io/bilibili-API-collect/docs/misc/sign/wbi.html">BAC Document：WBI 签名</a>
+ */
 public class WbiSigner {
+    private static final PercentEscaper ESCAPER = new PercentEscaper("-_.~", false);
     private static final String NAV_URL = "https://api.bilibili.com/x/web-interface/nav";
     private static final Gson GSON = new Gson();
-    private static final PercentEscaper escaper = new PercentEscaper("-_.~", false);
 
     private static final int[] MIXIN_KEY_ENC_TAB = new int[]{
             46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
@@ -27,7 +30,7 @@ public class WbiSigner {
             22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52
     };
 
-    static String WbiSign(Map<String, String> params) {
+    static String wbiSign(Map<String, String> params) {
         long wts = System.currentTimeMillis() / 1000L;
 
         String query = encodeQuery(params);
@@ -52,12 +55,14 @@ public class WbiSigner {
 
         boolean first = true;
         for (Map.Entry<String, String> entry : params.entrySet()) {
-            if (!first) query.append('&');
+            if (!first) {
+                query.append('&');
+            }
             first = false;
 
-            query.append(escaper.escape(entry.getKey()))
+            query.append(ESCAPER.escape(entry.getKey()))
                     .append("=")
-                    .append(escaper.escape(entry.getValue()));
+                    .append(ESCAPER.escape(entry.getValue()));
         }
 
         return query.toString();
@@ -65,12 +70,12 @@ public class WbiSigner {
 
     static String getMixinKey() {
         try {
-            // 获取img_url和sub_url
+            // 获取 img_url 和 sub_url
             HttpURLConnection conn = (HttpURLConnection) new URL(NAV_URL).openConnection();
 
             conn.setRequestMethod("GET");
-            conn.addRequestProperty("User-Agent", "Mozilla/5.0");
-            conn.addRequestProperty("Referer", "https://www.bilibili.com/");
+            conn.addRequestProperty(HttpHeaders.USER_AGENT, "Mozilla/5.0");
+            conn.addRequestProperty(HttpHeaders.REFERER, "https://www.bilibili.com/");
 
             String data = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
             conn.disconnect();
@@ -84,12 +89,14 @@ public class WbiSigner {
             String raw = imgKey + subKey;
             StringBuilder mixed = new StringBuilder();
             for (int idx : MIXIN_KEY_ENC_TAB) {
-                if (idx < raw.length()) mixed.append(raw.charAt(idx));
+                if (idx < raw.length()) {
+                    mixed.append(raw.charAt(idx));
+                }
             }
 
             return mixed.substring(0, 32);
         } catch (Exception e) {
-            e.printStackTrace();
+            BakaDanmaku.LOGGER.error(e);
         }
         return null;
     }

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WbiSigner.java
@@ -1,0 +1,93 @@
+package com.github.tartaricacid.bakadanmaku.site.bilibili;
+
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.common.net.PercentEscaper;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.TreeMap;
+
+
+public class WbiSigner {
+    private static final String NAV_URL = "https://api.bilibili.com/x/web-interface/nav";
+    private static final Gson GSON = new Gson();
+    private static final PercentEscaper escaper = new PercentEscaper("", false);
+
+    private static final int[] MIXIN_KEY_ENC_TAB = new int[]{
+            46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+            27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+            37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
+            22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52
+    };
+
+    static String WbiSign(Map<String, String> params) {
+        long wts = System.currentTimeMillis() / 1000L;
+
+        Map<String, String> copiedParams = new TreeMap<>(params);
+        String wRid = DigestUtils.md5Hex(encodeQuery(copiedParams) + getMixinKey());
+
+        params.put("wts", String.valueOf(wts));
+        params.put("w_rid", wRid);
+
+        return encodeQuery(params);
+    }
+
+    static String encodeQuery(Map<String, String> params) {
+        StringBuilder query = new StringBuilder();
+
+        boolean first = true;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (!first) query.append('&');
+            first = false;
+
+            query.append(escaper.escape(entry.getKey()))
+                    .append("=")
+                    .append(escaper.escape(entry.getValue()));
+        }
+
+        return query.toString();
+    }
+
+    static String getMixinKey() {
+        try {
+            // 获取img_url和sub_url
+            HttpURLConnection conn = (HttpURLConnection) new URL(NAV_URL).openConnection();
+
+            conn.setRequestMethod("GET");
+            conn.addRequestProperty("User-Agent", "Mozilla/5.0");
+            conn.addRequestProperty("Referer", "https://www.bilibili.com/");
+
+            String data = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+            conn.disconnect();
+
+            JsonObject response = GSON.fromJson(data, JsonObject.class);
+            JsonObject wbiImg = response.getAsJsonObject("data").getAsJsonObject("wbi_img");
+
+            String imgKey = getFileName(wbiImg.get("img_url").getAsString());
+            String subKey = getFileName(wbiImg.get("sub_url").getAsString());
+
+            String raw = imgKey + subKey;
+            StringBuilder mixed = new StringBuilder();
+            for (int idx : MIXIN_KEY_ENC_TAB) {
+                if (idx < raw.length()) mixed.append(raw.charAt(idx));
+            }
+
+            return mixed.substring(0, 32);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    static String getFileName(String url) {
+        String fullFileName = url.substring(url.lastIndexOf('/') + 1);
+        return fullFileName.substring(0, fullFileName.lastIndexOf('.'));
+    }
+}

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
@@ -9,9 +9,10 @@ import org.apache.commons.io.IOUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 
 public class WebSocketAuth {
-    private static final String INIT_URL = "https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo?id=%d&type=0";
+    private static final String INIT_URL = "https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo";
     private static final Gson GSON = new Gson();
     private static final String AUTH_FORMAT = "{\"uid\":%d,\"roomid\":%d,\"protover\":3,\"buvid\":\"%s\",\"platform\":\"web\",\"type\":2,\"key\":\"%s\"}";
 
@@ -65,7 +66,11 @@ public class WebSocketAuth {
 
         if (buvid3 == null) return null;
         try {
-            URL url = new URL(String.format(INIT_URL, roomInfo.getRoomId()));
+            HashMap<String, String> params = new HashMap<>();
+            params.put("id", String.valueOf(roomInfo.getRoomId()));
+            params.put("type", "0");
+
+            URL url = new URL(INIT_URL + "?" + WbiSigner.WbiSign(params));
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             try {
                 conn.addRequestProperty("Cookie", cookie);

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
@@ -2,12 +2,14 @@ package com.github.tartaricacid.bakadanmaku.site.bilibili;
 
 import com.github.tartaricacid.bakadanmaku.BakaDanmaku;
 import com.github.tartaricacid.bakadanmaku.config.BilibiliConfig;
+import com.google.common.net.HttpHeaders;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.IOUtils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -18,7 +20,9 @@ public class WebSocketAuth {
 
     public static byte[] newAuth(BilibiliConfig.Room room) {
         RoomInfo roomInfo = RoomInfo.getRoomInfo(room.getId());
-        if (roomInfo == null) return null;
+        if (roomInfo == null) {
+            return null;
+        }
 
         if (room.isManualAuth()) {
             return room
@@ -30,54 +34,50 @@ public class WebSocketAuth {
         String cookie = "";
         String buvid3 = "";
         boolean ownerAuth = true;
-        try {
-            if (room.getCookie() == null) {
-                // 游客方式
-                ownerAuth = false;
-                Buvid buvid = Buvid.newBuvid(roomInfo.getRoomId());
-                if (buvid != null) {
-                    cookie = String.format(
-                            "buvid3=%s; buvid4=%s",
-                            URLEncoder.encode(buvid.getBuvid3(), "UTF-8"),
-                            URLEncoder.encode(buvid.getBuvid4(), "UTF-8")
-                    );
-                    buvid3 = buvid.getBuvid3();
-                }
-                BakaDanmaku.LOGGER.info("[BakaDanmaku] Login Be Guest");
-            } else {
-                // 登陆方式
-                buvid3 = room.getCookie().getOrDefault("buvid3", Buvid.getBuvid3(roomInfo.getRoomId()));
-                StringBuilder sb = new StringBuilder();
-                room.getCookie().forEach((k, v) -> {
-                    if ("buvid3".equals(k)) return;
-                    try {
-                        v = URLEncoder.encode(v, "UTF-8");
-                    } catch (UnsupportedEncodingException ignored) {
-
-                    }
-                    sb.append(k).append("=").append(v).append("; ");
-                });
-                cookie = String.format("buvid3=%s; %s", URLEncoder.encode(buvid3, "UTF-8"), sb);
-                BakaDanmaku.LOGGER.info("[BakaDanmaku] Login Be User");
+        if (room.getCookie() == null) {
+            // 游客方式
+            ownerAuth = false;
+            Buvid buvid = Buvid.newBuvid(roomInfo.getRoomId());
+            if (buvid != null) {
+                cookie = String.format(
+                        "buvid3=%s; buvid4=%s",
+                        URLEncoder.encode(buvid.getBuvid3(), StandardCharsets.UTF_8),
+                        URLEncoder.encode(buvid.getBuvid4(), StandardCharsets.UTF_8)
+                );
+                buvid3 = buvid.getBuvid3();
             }
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+            BakaDanmaku.LOGGER.info("[BakaDanmaku] Login Be Guest");
+        } else {
+            // 登陆方式
+            buvid3 = room.getCookie().getOrDefault("buvid3", Buvid.getBuvid3(roomInfo.getRoomId()));
+            StringBuilder sb = new StringBuilder();
+            room.getCookie().forEach((k, v) -> {
+                if ("buvid3".equals(k)) {
+                    return;
+                }
+                v = URLEncoder.encode(v, StandardCharsets.UTF_8);
+                sb.append(k).append("=").append(v).append("; ");
+            });
+            cookie = String.format("buvid3=%s; %s", URLEncoder.encode(buvid3, StandardCharsets.UTF_8), sb);
+            BakaDanmaku.LOGGER.info("[BakaDanmaku] Login Be User");
         }
 
-        if (buvid3 == null) return null;
+        if (buvid3 == null) {
+            return null;
+        }
         try {
             HashMap<String, String> params = new HashMap<>();
             params.put("id", String.valueOf(roomInfo.getRoomId()));
             params.put("type", "0");
 
-            URL url = new URL(INIT_URL + "?" + WbiSigner.WbiSign(params));
+            URL url = new URL(INIT_URL + "?" + WbiSigner.wbiSign(params));
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             try {
-                conn.addRequestProperty("Cookie", cookie);
+                conn.addRequestProperty(HttpHeaders.COOKIE, cookie);
                 conn.setRequestMethod("GET");
-                conn.addRequestProperty("User-Agent", "Mozilla/5.0");
-                conn.addRequestProperty("Referer", "https://www.bilibili.com/");
-                String data = IOUtils.toString(conn.getInputStream());
+                conn.addRequestProperty(HttpHeaders.USER_AGENT, "Mozilla/5.0");
+                conn.addRequestProperty(HttpHeaders.REFERER, "https://www.bilibili.com/");
+                String data = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
                 JsonObject response = GSON.fromJson(data, JsonObject.class);
                 String token = response.getAsJsonObject("data").get("token").getAsString();
                 String auth = String.format(
@@ -88,7 +88,7 @@ public class WebSocketAuth {
                 conn.disconnect();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            BakaDanmaku.LOGGER.error(e);
         }
         return null;
     }
@@ -116,7 +116,7 @@ public class WebSocketAuth {
                         obj.get("b_4").getAsString()
                 );
             } catch (Exception e) {
-                e.printStackTrace();
+                BakaDanmaku.LOGGER.error(e);
             }
             return null;
         }

--- a/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
+++ b/src/main/java/com/github/tartaricacid/bakadanmaku/site/bilibili/WebSocketAuth.java
@@ -75,6 +75,8 @@ public class WebSocketAuth {
             try {
                 conn.addRequestProperty("Cookie", cookie);
                 conn.setRequestMethod("GET");
+                conn.addRequestProperty("User-Agent", "Mozilla/5.0");
+                conn.addRequestProperty("Referer", "https://www.bilibili.com/");
                 String data = IOUtils.toString(conn.getInputStream());
                 JsonObject response = GSON.fromJson(data, JsonObject.class);
                 String token = response.getAsJsonObject("data").get("token").getAsString();


### PR DESCRIPTION
由于无法获取房间，经过和[API文档](https://socialsisteryi.github.io/bilibili-API-collect/docs/live/message_stream.html)的比对后，发现从2025年5月26日开始信息流认证秘钥API需要Wbi签名
参考[WBI 签名](https://socialsisteryi.github.io/bilibili-API-collect/docs/misc/sign/wbi.html)页面添加了签名部分的代码